### PR TITLE
Normalize Azure repository URLs in pipeline task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
 
       - run: pnpm run lint
 
+      - run: pnpm run test
+
       - run: pnpm run build
 
       - run: pnpm run package

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node esbuild.mts",
     "lint": "biome check ./src",
+    "test": "node --test --experimental-strip-types src/*.test.mts",
     "format": "biome format --write ./src",
     "package": "tfx extension create"
   },

--- a/src/arguments.mts
+++ b/src/arguments.mts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import { normalizeAzureRepositoryUri } from "./repository-url.mts";
+
+export function getResultsFileName(env: NodeJS.ProcessEnv): string {
+  const resultsFile = env["INPUT_RESULTSFILE"];
+  if (resultsFile) {
+    return resultsFile;
+  }
+  if (env["INPUT_RESULTSFORMAT"] === "json") {
+    return "scorecard-results.json";
+  }
+  return "scorecard-results.sarif";
+}
+
+export function getScorecardArguments(
+  env: NodeJS.ProcessEnv,
+  taskDirectory: string,
+): string[] {
+  const repository = env["BUILD_REPOSITORY_URI"];
+  if (!repository) {
+    throw new Error("BUILD_REPOSITORY_URI environment variable is required");
+  }
+
+  const resultsFormat = env["INPUT_RESULTSFORMAT"] || "sarif";
+  const resultsPolicy =
+    env["INPUT_RESULTSPOLICY"] || path.join(taskDirectory, "policy.yml");
+
+  return [
+    "--repo",
+    normalizeAzureRepositoryUri(repository),
+    "--format",
+    resultsFormat,
+    "--output",
+    getResultsFileName(env),
+    "--policy",
+    resultsPolicy,
+  ];
+}

--- a/src/arguments.test.mts
+++ b/src/arguments.test.mts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+import { getResultsFileName, getScorecardArguments } from "./arguments.mts";
+
+test("builds Scorecard arguments with defaults", () => {
+  const taskDirectory = "/task";
+  const args = getScorecardArguments(
+    {
+      BUILD_REPOSITORY_URI:
+        "https://contoso.visualstudio.com/project/_git/repository",
+    },
+    taskDirectory,
+  );
+
+  assert.deepEqual(args, [
+    "--repo",
+    "https://dev.azure.com/contoso/project/_git/repository",
+    "--format",
+    "sarif",
+    "--output",
+    "scorecard-results.sarif",
+    "--policy",
+    path.join(taskDirectory, "policy.yml"),
+  ]);
+});
+
+test("builds Scorecard arguments with explicit inputs", () => {
+  const args = getScorecardArguments(
+    {
+      BUILD_REPOSITORY_URI:
+        "https://contoso@dev.azure.com/contoso/project/_git/repository",
+      INPUT_RESULTSFILE: "results/custom.json",
+      INPUT_RESULTSFORMAT: "json",
+      INPUT_RESULTSPOLICY: "/repo/custom-policy.yml",
+    },
+    "/task",
+  );
+
+  assert.deepEqual(args, [
+    "--repo",
+    "https://dev.azure.com/contoso/project/_git/repository",
+    "--format",
+    "json",
+    "--output",
+    "results/custom.json",
+    "--policy",
+    "/repo/custom-policy.yml",
+  ]);
+});
+
+test("selects the default results filename", () => {
+  assert.equal(getResultsFileName({}), "scorecard-results.sarif");
+  assert.equal(
+    getResultsFileName({ INPUT_RESULTSFORMAT: "json" }),
+    "scorecard-results.json",
+  );
+  assert.equal(
+    getResultsFileName({
+      INPUT_RESULTSFILE: "custom.sarif",
+      INPUT_RESULTSFORMAT: "json",
+    }),
+    "custom.sarif",
+  );
+});
+
+test("requires BUILD_REPOSITORY_URI", () => {
+  assert.throws(
+    () => getScorecardArguments({}, "/task"),
+    new Error("BUILD_REPOSITORY_URI environment variable is required"),
+  );
+});
+
+test("rejects unsupported repository hosts before execution", () => {
+  assert.throws(
+    () =>
+      getScorecardArguments(
+        { BUILD_REPOSITORY_URI: "https://github.com/contoso/repository" },
+        "/task",
+      ),
+    new Error("Unsupported BUILD_REPOSITORY_URI host: github.com"),
+  );
+});

--- a/src/index.mts
+++ b/src/index.mts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { extract } from "tar/extract";
+import { getResultsFileName, getScorecardArguments } from "./arguments.mts";
 
 /**
  * Get the latest version of Scorecard from GitHub.
@@ -175,60 +176,13 @@ async function extractTarGz(filePath: string): Promise<string> {
 }
 
 /**
- * Get the path to the results file.
- * Uses the `INPUT_RESULTSFILE` environment variable.
- * If not set, defaults to `results.sarif` or `results.json` based on the `INPUT_RESULTSFORMAT` environment variable.
- * @returns {string} The path to the results file.
- */
-function getResultsFileName(): string {
-  const resultsFile = process.env["INPUT_RESULTSFILE"];
-  if (resultsFile) {
-    return resultsFile;
-  }
-  const resultsFormat = process.env["INPUT_RESULTSFORMAT"];
-  if (resultsFormat === "json") {
-    return "scorecard-results.json";
-  }
-  return "scorecard-results.sarif";
-}
-
-/**
- * Get the arguments to pass to the Scorecard binary.
- * @returns {string[]} The arguments to pass to the Scorecard binary.
- */
-function getArguments(): string[] {
-  const args: string[] = [];
-
-  const repository = process.env["BUILD_REPOSITORY_URI"];
-  if (!repository) {
-    throw new Error("BUILD_REPOSITORY_URI environment variable is required");
-  }
-  args.push("--repo", repository);
-
-  const resultsFormat = process.env["INPUT_RESULTSFORMAT"] || "sarif";
-  args.push("--format", resultsFormat);
-
-  args.push("--output", getResultsFileName());
-
-  const resultsPolicy = process.env["INPUT_RESULTSPOLICY"];
-  if (resultsPolicy) {
-    args.push("--policy", resultsPolicy);
-  } else {
-    const defaultPolicy = path.join(import.meta.dirname, "policy.yml");
-    args.push("--policy", defaultPolicy);
-  }
-
-  return args;
-}
-
-/**
  * Run the Scorecard binary.
  * @async
  * @param binary The path to the Scorecard binary.
+ * @param args The arguments to pass to the Scorecard binary.
  * @returns {Promise<void>} A promise that resolves when the command is executed.
  */
-async function runScorecard(binary: string): Promise<void> {
-  const args = getArguments();
+async function runScorecard(binary: string, args: string[]): Promise<void> {
   const env = {
     ...process.env,
     AZURE_DEVOPS_AUTH_TOKEN: process.env["INPUT_REPOTOKEN"],
@@ -274,7 +228,7 @@ const githubOnlyChecks = new Set([
  * and removes results for GitHub-only checks.
  */
 async function fixSarifForAdvSec(): Promise<void> {
-  const resultsFile = path.join(process.cwd(), getResultsFileName());
+  const resultsFile = path.join(process.cwd(), getResultsFileName(process.env));
   if (!resultsFile.endsWith(".sarif")) {
     return;
   }
@@ -333,7 +287,7 @@ async function fixSarifForAdvSec(): Promise<void> {
  * @see https://learn.microsoft.com/azure/devops/pipelines/scripts/logging-commands#upload-upload-an-artifact
  */
 async function uploadResults(): Promise<void> {
-  const resultsFileName = getResultsFileName();
+  const resultsFileName = getResultsFileName(process.env);
   const resultsFile = path.join(process.cwd(), resultsFileName);
 
   // Verify the results file exists before uploading
@@ -373,6 +327,10 @@ async function run(): Promise<void> {
   const tempFiles: string[] = [];
   try {
     console.log("Starting Scorecard Azure Pipelines task...");
+    const scorecardArguments = getScorecardArguments(
+      process.env,
+      import.meta.dirname,
+    );
 
     const downloadUrl = await getDownloadUrl();
     console.log(`Downloading Scorecard from: ${downloadUrl}`);
@@ -389,7 +347,7 @@ async function run(): Promise<void> {
     tempFiles.push(binary);
 
     console.log("Running Scorecard...");
-    await runScorecard(binary);
+    await runScorecard(binary, scorecardArguments);
 
     await fixSarifForAdvSec();
 

--- a/src/repository-url.mts
+++ b/src/repository-url.mts
@@ -1,0 +1,75 @@
+const azureDevOpsHost = "dev.azure.com";
+const visualStudioHostSuffix = ".visualstudio.com";
+
+function getPathSegments(url: URL): string[] {
+  return url.pathname.split("/").slice(1);
+}
+
+function invalidPath(host: string, expected: string): never {
+  throw new Error(
+    `Invalid BUILD_REPOSITORY_URI path for ${host}; expected ${expected}`,
+  );
+}
+
+export function normalizeAzureRepositoryUri(value: string): string {
+  let repositoryUrl: URL;
+  try {
+    repositoryUrl = new URL(value);
+  } catch {
+    throw new Error("BUILD_REPOSITORY_URI must be a valid absolute URL");
+  }
+
+  if (repositoryUrl.protocol !== "https:") {
+    throw new Error("BUILD_REPOSITORY_URI must use HTTPS");
+  }
+  if (repositoryUrl.port) {
+    throw new Error("BUILD_REPOSITORY_URI must not specify a port");
+  }
+
+  const host = repositoryUrl.hostname;
+  const segments = getPathSegments(repositoryUrl);
+
+  let organization: string;
+  let project: string;
+  let repository: string;
+
+  if (host === azureDevOpsHost) {
+    const [organizationSegment, projectSegment, gitSegment, repositorySegment] =
+      segments;
+    if (
+      segments.length !== 4 ||
+      !organizationSegment ||
+      !projectSegment ||
+      gitSegment?.toLowerCase() !== "_git" ||
+      !repositorySegment
+    ) {
+      invalidPath(host, "/<organization>/<project>/_git/<repository>");
+    }
+
+    organization = organizationSegment;
+    project = projectSegment;
+    repository = repositorySegment;
+  } else if (host.endsWith(visualStudioHostSuffix)) {
+    const organizationSegment = host.slice(0, -visualStudioHostSuffix.length);
+    const [projectSegment, gitSegment, repositorySegment] = segments;
+    if (!organizationSegment || organizationSegment.includes(".")) {
+      throw new Error(`Unsupported BUILD_REPOSITORY_URI host: ${host}`);
+    }
+    if (
+      segments.length !== 3 ||
+      !projectSegment ||
+      gitSegment?.toLowerCase() !== "_git" ||
+      !repositorySegment
+    ) {
+      invalidPath(host, "/<project>/_git/<repository>");
+    }
+
+    organization = organizationSegment;
+    project = projectSegment;
+    repository = repositorySegment;
+  } else {
+    throw new Error(`Unsupported BUILD_REPOSITORY_URI host: ${host}`);
+  }
+
+  return `https://${azureDevOpsHost}/${organization}/${project}/_git/${repository}`;
+}

--- a/src/repository-url.test.mts
+++ b/src/repository-url.test.mts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeAzureRepositoryUri } from "./repository-url.mts";
+
+test("normalizes Azure DevOps repository URLs", async (t) => {
+  const cases = [
+    {
+      name: "canonical URL",
+      input: "https://dev.azure.com/contoso/project/_git/repository",
+      expected: "https://dev.azure.com/contoso/project/_git/repository",
+    },
+    {
+      name: "canonical URL with user information",
+      input: "https://contoso@dev.azure.com/contoso/project/_git/repository",
+      expected: "https://dev.azure.com/contoso/project/_git/repository",
+    },
+    {
+      name: "legacy Visual Studio URL",
+      input: "https://contoso.visualstudio.com/project/_git/repository",
+      expected: "https://dev.azure.com/contoso/project/_git/repository",
+    },
+    {
+      name: "encoded project and repository names",
+      input: "https://contoso.visualstudio.com/Project%20Name/_git/Repo%20Name",
+      expected: "https://dev.azure.com/contoso/Project%20Name/_git/Repo%20Name",
+    },
+    {
+      name: "query and fragment are removed",
+      input:
+        "https://dev.azure.com/contoso/project/_git/repository?version=1#readme",
+      expected: "https://dev.azure.com/contoso/project/_git/repository",
+    },
+    {
+      name: "_git matching is case-insensitive",
+      input: "https://contoso.visualstudio.com/project/_GIT/repository",
+      expected: "https://dev.azure.com/contoso/project/_git/repository",
+    },
+  ] as const;
+
+  for (const testcase of cases) {
+    await t.test(testcase.name, () => {
+      assert.equal(
+        normalizeAzureRepositoryUri(testcase.input),
+        testcase.expected,
+      );
+    });
+  }
+});
+
+test("rejects unsupported or malformed repository URLs", async (t) => {
+  const cases = [
+    {
+      name: "relative URL",
+      input: "dev.azure.com/contoso/project/_git/repository",
+      message: "BUILD_REPOSITORY_URI must be a valid absolute URL",
+    },
+    {
+      name: "non-HTTPS URL",
+      input: "http://dev.azure.com/contoso/project/_git/repository",
+      message: "BUILD_REPOSITORY_URI must use HTTPS",
+    },
+    {
+      name: "URL with port",
+      input: "https://dev.azure.com:8443/contoso/project/_git/repository",
+      message: "BUILD_REPOSITORY_URI must not specify a port",
+    },
+    {
+      name: "unsupported host",
+      input: "https://github.com/contoso/repository",
+      message: "Unsupported BUILD_REPOSITORY_URI host: github.com",
+    },
+    {
+      name: "nested Visual Studio host",
+      input: "https://foo.bar.visualstudio.com/project/_git/repository",
+      message:
+        "Unsupported BUILD_REPOSITORY_URI host: foo.bar.visualstudio.com",
+    },
+    {
+      name: "canonical URL missing repository",
+      input: "https://dev.azure.com/contoso/project/_git",
+      message:
+        "Invalid BUILD_REPOSITORY_URI path for dev.azure.com; expected /<organization>/<project>/_git/<repository>",
+    },
+    {
+      name: "canonical URL missing _git",
+      input: "https://dev.azure.com/contoso/project/repository",
+      message:
+        "Invalid BUILD_REPOSITORY_URI path for dev.azure.com; expected /<organization>/<project>/_git/<repository>",
+    },
+    {
+      name: "legacy URL missing repository",
+      input: "https://contoso.visualstudio.com/project/_git",
+      message:
+        "Invalid BUILD_REPOSITORY_URI path for contoso.visualstudio.com; expected /<project>/_git/<repository>",
+    },
+    {
+      name: "legacy URL with extra path segment",
+      input: "https://contoso.visualstudio.com/project/_git/repository/extra",
+      message:
+        "Invalid BUILD_REPOSITORY_URI path for contoso.visualstudio.com; expected /<project>/_git/<repository>",
+    },
+  ] as const;
+
+  for (const testcase of cases) {
+    await t.test(testcase.name, () => {
+      assert.throws(
+        () => normalizeAzureRepositoryUri(testcase.input),
+        new Error(testcase.message),
+      );
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
   ],
   "include": ["src"],
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "module": "preserve",
     "moduleResolution": "bundler",
     "noEmit": true,


### PR DESCRIPTION
Normalizes legacy `*.visualstudio.com` repository URLs before invoking Scorecard and adds native Node tests.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>