### PR TITLE
Add stable categories to Scorecard SARIF runs

### DIFF
--- a/src/sarif.mts
+++ b/src/sarif.mts
@@ -38,7 +38,25 @@ function requireMessage(value: unknown, path: string): void {
   }
 }
 
-function prepareRun(value: unknown, runIndex: number): void {
+function getRunCategory(run: JsonObject, runPath: string): string {
+  const automationDetails = requireObject(
+    run["automationDetails"],
+    `${runPath}.automationDetails`,
+  );
+  const id = requireNonemptyString(
+    automationDetails["id"],
+    `${runPath}.automationDetails.id`,
+  );
+  const category = id.split("/")[1];
+  if (!category) {
+    throw new Error(
+      `Invalid SARIF: ${runPath}.automationDetails.id must contain a run category`,
+    );
+  }
+  return `scorecard-${category}`;
+}
+
+function prepareRun(value: unknown, runIndex: number): string {
   const runPath = `runs[${runIndex}]`;
   const run = requireObject(value, runPath);
   const tool = requireObject(run["tool"], `${runPath}.tool`);
@@ -64,6 +82,14 @@ function prepareRun(value: unknown, runIndex: number): void {
   }
   driver["version"] = normalizedVersion;
   driver["semanticVersion"] = normalizedVersion;
+
+  const category = getRunCategory(run, runPath);
+  const properties =
+    run["properties"] === undefined
+      ? {}
+      : requireObject(run["properties"], `${runPath}.properties`);
+  properties["category"] = category;
+  run["properties"] = properties;
 
   const ruleIds = rules.map((ruleValue, ruleIndex) => {
     const rulePath = `${runPath}.tool.driver.rules[${ruleIndex}]`;
@@ -104,6 +130,8 @@ function prepareRun(value: unknown, runIndex: number): void {
       );
     }
   }
+
+  return category;
 }
 
 export function prepareSarifForAdvancedSecurity(content: string): string {
@@ -124,8 +152,13 @@ export function prepareSarifForAdvancedSecurity(content: string): string {
     throw new Error("Invalid SARIF: runs must not be empty");
   }
 
+  const categories = new Set<string>();
   for (const [runIndex, run] of runs.entries()) {
-    prepareRun(run, runIndex);
+    const category = prepareRun(run, runIndex);
+    if (categories.has(category)) {
+      throw new Error(`Invalid SARIF: duplicate run category "${category}"`);
+    }
+    categories.add(category);
   }
 
   return JSON.stringify(sarif, null, 2);

--- a/src/sarif.test.mts
+++ b/src/sarif.test.mts
@@ -20,9 +20,18 @@ function prepare(value: unknown) {
 test("preserves Scorecard multi-run SARIF", () => {
   const original = fixtureValue();
   const expected = structuredClone(original);
-  for (const run of expected.runs) {
+  const categories = [
+    "scorecard-branch-protection",
+    "scorecard-local",
+    "scorecard-online-scm",
+  ];
+  for (const [index, run] of expected.runs.entries()) {
     run.tool.driver.version = "5.5.0";
     run.tool.driver.semanticVersion = "5.5.0";
+    run.properties = {
+      ...(run.properties ?? {}),
+      category: categories[index],
+    };
   }
 
   const prepared = prepare(original);
@@ -44,6 +53,12 @@ test("preserves Scorecard multi-run SARIF", () => {
       0,
     ),
     5,
+  );
+  assert.deepEqual(
+    prepared.runs.map(
+      (run: { properties: { category: string } }) => run.properties.category,
+    ),
+    categories,
   );
 });
 
@@ -130,6 +145,38 @@ test("rejects invalid rule indices", () => {
 });
 
 test("rejects missing run structure", () => {
+  const missingAutomationDetails = fixtureValue();
+  delete missingAutomationDetails.runs[0].automationDetails;
+  assert.throws(
+    () => prepare(missingAutomationDetails),
+    new Error("Invalid SARIF: runs[0].automationDetails must be an object"),
+  );
+
+  const missingAutomationID = fixtureValue();
+  delete missingAutomationID.runs[0].automationDetails.id;
+  assert.throws(
+    () => prepare(missingAutomationID),
+    new Error(
+      "Invalid SARIF: runs[0].automationDetails.id must be a nonempty string",
+    ),
+  );
+
+  const missingCategory = fixtureValue();
+  missingCategory.runs[0].automationDetails.id = "scorecard";
+  assert.throws(
+    () => prepare(missingCategory),
+    new Error(
+      "Invalid SARIF: runs[0].automationDetails.id must contain a run category",
+    ),
+  );
+
+  const invalidProperties = fixtureValue();
+  invalidProperties.runs[0].properties = "invalid";
+  assert.throws(
+    () => prepare(invalidProperties),
+    new Error("Invalid SARIF: runs[0].properties must be an object"),
+  );
+
   const missingDriverName = fixtureValue();
   delete missingDriverName.runs[0].tool.driver.name;
   assert.throws(
@@ -182,6 +229,19 @@ test("rejects missing run structure", () => {
     () => prepare(emptyMessage),
     new Error(
       "Invalid SARIF: runs[0].results[0].message must contain nonempty text or markdown",
+    ),
+  );
+});
+
+test("rejects duplicate run categories", () => {
+  const sarif = fixtureValue();
+  sarif.runs[1].automationDetails.id =
+    "supply-chain/branch-protection/another-run";
+
+  assert.throws(
+    () => prepare(sarif),
+    new Error(
+      'Invalid SARIF: duplicate run category "scorecard-branch-protection"',
     ),
   );
 });


### PR DESCRIPTION
Adds stable categories to each Scorecard SARIF run so Advanced Security keeps findings from all three runs active.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>