### PR TITLE
Use unique Scorecard extraction directories

### DIFF
--- a/src/extract.mts
+++ b/src/extract.mts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { extract } from "tar/extract";
+
+export interface ExtractedScorecard {
+  directory: string;
+  binaryPath: string;
+}
+
+export async function extractScorecardArchive(
+  archivePath: string,
+  tempRoot: string = os.tmpdir(),
+  platform: NodeJS.Platform = os.platform(),
+): Promise<ExtractedScorecard> {
+  const directory = await fs.promises.mkdtemp(
+    path.join(tempRoot, "scorecard-"),
+  );
+
+  try {
+    await extract({
+      file: archivePath,
+      cwd: directory,
+      gzip: true,
+      filter: (file) => file.startsWith("scorecard"),
+    });
+
+    const suffix = platform === "win32" ? ".exe" : "";
+    const binaryPath = path.join(directory, `scorecard${suffix}`);
+    await fs.promises.access(binaryPath);
+
+    return { directory, binaryPath };
+  } catch (error) {
+    try {
+      await fs.promises.rm(directory, { force: true, recursive: true });
+    } catch {
+      // Preserve the original extraction error.
+    }
+    throw error;
+  }
+}

--- a/src/extract.test.mts
+++ b/src/extract.test.mts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type TestContext, test } from "node:test";
+import { create } from "tar/create";
+import { extractScorecardArchive } from "./extract.mts";
+
+async function testDirectory(t: TestContext): Promise<string> {
+  const directory = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "scorecard-extract-test-"),
+  );
+  t.after(async () => {
+    await fs.promises.rm(directory, { force: true, recursive: true });
+  });
+  return directory;
+}
+
+async function createArchive(
+  root: string,
+  files: Record<string, string>,
+): Promise<string> {
+  const source = path.join(root, "source");
+  await fs.promises.mkdir(source);
+  for (const [filename, content] of Object.entries(files)) {
+    await fs.promises.writeFile(path.join(source, filename), content);
+  }
+
+  const archive = path.join(root, "scorecard.tar.gz");
+  await create(
+    {
+      cwd: source,
+      file: archive,
+      gzip: true,
+    },
+    Object.keys(files),
+  );
+  return archive;
+}
+
+async function extractionDirectories(root: string): Promise<string[]> {
+  return (await fs.promises.readdir(root)).filter((entry) =>
+    entry.startsWith("scorecard-"),
+  );
+}
+
+test("extracts the Linux binary and filters unrelated files", async (t) => {
+  const root = await testDirectory(t);
+  const archive = await createArchive(root, {
+    README: "filtered",
+    scorecard: "linux binary",
+  });
+
+  const extracted = await extractScorecardArchive(archive, root, "linux");
+
+  assert.match(path.basename(extracted.directory), /^scorecard-/);
+  assert.equal(
+    await fs.promises.readFile(extracted.binaryPath, "utf8"),
+    "linux binary",
+  );
+  await assert.rejects(
+    fs.promises.access(path.join(extracted.directory, "README")),
+    { code: "ENOENT" },
+  );
+});
+
+test("selects scorecard.exe for Windows", async (t) => {
+  const root = await testDirectory(t);
+  const archive = await createArchive(root, {
+    "scorecard.exe": "windows binary",
+  });
+
+  const extracted = await extractScorecardArchive(archive, root, "win32");
+
+  assert.equal(path.basename(extracted.binaryPath), "scorecard.exe");
+  assert.equal(
+    await fs.promises.readFile(extracted.binaryPath, "utf8"),
+    "windows binary",
+  );
+});
+
+test("isolates concurrent extractions", async (t) => {
+  const root = await testDirectory(t);
+  const archive = await createArchive(root, {
+    scorecard: "binary",
+  });
+
+  const [first, second] = await Promise.all([
+    extractScorecardArchive(archive, root, "linux"),
+    extractScorecardArchive(archive, root, "linux"),
+  ]);
+
+  assert.notEqual(first.directory, second.directory);
+  assert.notEqual(first.binaryPath, second.binaryPath);
+  await fs.promises.rm(first.directory, { recursive: true });
+  await assert.rejects(fs.promises.access(first.binaryPath), {
+    code: "ENOENT",
+  });
+  assert.equal(await fs.promises.readFile(second.binaryPath, "utf8"), "binary");
+});
+
+test("cleans the generated directory for an invalid archive", async (t) => {
+  const root = await testDirectory(t);
+  const archive = path.join(root, "invalid.tar.gz");
+  await fs.promises.writeFile(archive, "not an archive");
+
+  await assert.rejects(extractScorecardArchive(archive, root, "linux"));
+  assert.deepEqual(await extractionDirectories(root), []);
+});
+
+test("cleans the generated directory when the binary is missing", async (t) => {
+  const root = await testDirectory(t);
+  const archive = await createArchive(root, {
+    README: "no binary",
+  });
+
+  await assert.rejects(extractScorecardArchive(archive, root, "linux"));
+  assert.deepEqual(await extractionDirectories(root), []);
+});

--- a/src/index.mts
+++ b/src/index.mts
@@ -4,13 +4,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { extract } from "tar/extract";
 import {
   getResultsFileName,
   getResultsFormat,
   getScorecardArguments,
 } from "./arguments.mts";
 import { downloadToFile } from "./download.mts";
+import { extractScorecardArchive } from "./extract.mts";
 import { prepareResultsForUpload } from "./results.mts";
 import { runScorecardProcess } from "./scorecard-process.mts";
 import { getTaskCompletionMessages } from "./task-result.mts";
@@ -131,35 +131,6 @@ async function verifyChecksum(
 }
 
 /**
- * Extract a .tar.gz file to a destination directory.
- * @async
- * @param filePath The path to the .tar.gz file.
- * @returns {Promise<string>} The path to the extracted Scorecard binary.
- */
-async function extractTarGz(filePath: string): Promise<string> {
-  const dest = path.join(os.tmpdir(), "scorecard");
-  await fs.promises.mkdir(dest, { recursive: true });
-
-  await extract({
-    file: filePath,
-    cwd: dest,
-    gzip: true,
-    filter: (file) => file.startsWith("scorecard"),
-  });
-
-  const suffix = getOs() === "windows" ? ".exe" : "";
-  const binaryPath = path.join(dest, `scorecard${suffix}`);
-
-  try {
-    await fs.promises.access(binaryPath);
-  } catch {
-    throw new Error(`Scorecard binary not found at ${binaryPath}`);
-  }
-
-  return binaryPath;
-}
-
-/**
  * Validate and prepare the Scorecard result file for upload.
  */
 async function prepareResultsFileForUpload(): Promise<void> {
@@ -199,12 +170,16 @@ async function uploadResults(): Promise<void> {
 }
 
 /**
- * Clean up temporary files.
+ * Clean up temporary files and directories.
  * @param filePaths The file paths to clean up.
+ * @param directoryPaths The directory paths to clean up recursively.
  */
-async function cleanup(filePaths: string[]): Promise<void> {
-  await Promise.allSettled(
-    filePaths.map(async (filePath) => {
+async function cleanup(
+  filePaths: string[],
+  directoryPaths: string[],
+): Promise<void> {
+  await Promise.allSettled([
+    ...filePaths.map(async (filePath) => {
       try {
         await fs.promises.unlink(filePath);
         console.log(`Cleaned up: ${filePath}`);
@@ -212,7 +187,18 @@ async function cleanup(filePaths: string[]): Promise<void> {
         // Ignore cleanup errors
       }
     }),
-  );
+    ...directoryPaths.map(async (directoryPath) => {
+      try {
+        await fs.promises.rm(directoryPath, {
+          force: true,
+          recursive: true,
+        });
+        console.log(`Cleaned up: ${directoryPath}`);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }),
+  ]);
 }
 
 /**
@@ -222,6 +208,7 @@ async function cleanup(filePaths: string[]): Promise<void> {
  */
 async function run(): Promise<number> {
   const tempFiles: string[] = [];
+  const tempDirectories: string[] = [];
   try {
     console.log("Starting Scorecard Azure Pipelines task...");
     const scorecardArguments = getScorecardArguments(
@@ -240,8 +227,9 @@ async function run(): Promise<number> {
     await verifyChecksum(downloadUrl, filename);
 
     console.log("Extracting binary...");
-    const binary = await extractTarGz(filename);
-    tempFiles.push(binary);
+    const extracted = await extractScorecardArchive(filename);
+    tempDirectories.push(extracted.directory);
+    const binary = extracted.binaryPath;
 
     console.log("Running Scorecard...");
     console.log(`Running: ${binary} ${scorecardArguments.join(" ")}`);
@@ -266,8 +254,7 @@ async function run(): Promise<number> {
     console.error("Scorecard task failed:", error);
     throw error;
   } finally {
-    // Clean up temporary files
-    await cleanup(tempFiles);
+    await cleanup(tempFiles, tempDirectories);
   }
 }
 


### PR DESCRIPTION
Extracts each Scorecard binary into its own temporary directory so concurrent jobs never share the same executable path.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>